### PR TITLE
CVE-2021-45105 addressed in Log4j 2.17.0 for Java 8 and up.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
         <!-- Version Management -->
         <commons_cli>1.4</commons_cli>
-        <log4j2>2.16.0</log4j2>
+        <log4j2>2.17.0</log4j2>
         <junit>5.6.2</junit>
         <surefire>2.22.1</surefire>
     </properties>


### PR DESCRIPTION
Important: Security Vulnerability CVE-2021-45105
The Log4j team has been made aware of a security vulnerability, CVE-2021-45105, that has been addressed in Log4j 2.17.0 for Java 8 and up.

Summary: Apache Log4j2 does not always protect from infinite recursion in lookup evaluation.